### PR TITLE
add contribute link to docs site for consistency-sake

### DIFF
--- a/source/_layouts/documentation.blade.php
+++ b/source/_layouts/documentation.blade.php
@@ -10,6 +10,9 @@
                 </a>
             </div>
             <div>
+                <a href="https://github.com/tightenco/jigsaw" class="link-brand m-xs-r-6">
+                    Contribute
+                </a>
                 <a href="{{ $asset_prefix }}/docs/installation/" class="btn btn-primary-outline">
                     Docs
                 </a>


### PR DESCRIPTION
I'm not sure if this was intentionally left off, but once I got to the docs, I couldn't subsequently click through to the GitHub repo.