### PR TITLE
Adding pagination perPage default value on docs

### DIFF
--- a/source/docs/collections-pagination.md
+++ b/source/docs/collections-pagination.md
@@ -21,6 +21,8 @@ pagination:
 ...
 ```
 
+> Note that if you don't provide a `perPage` value, then the default value will be 10.
+
 Once the `pagination` has been defined in the header, the template will have access to a special `$pagination` variable, which has several attributes:
 
 - `$pagination->items` contains an array of collection items for the current page


### PR DESCRIPTION
There is a lack of information when docs don't tell what is the default value of options.