### PR TITLE
Update Laravel version references

### DIFF
--- a/build_production/docs/blade-templates-and-partials/index.html
+++ b/build_production/docs/blade-templates-and-partials/index.html
@@ -81,7 +81,7 @@
         </div>
         <div class="col-md-9 documentation-page">
             <h2>Blade Templates &amp; Partials</h2>
-<p>One of the biggest benefits of a templating language is the ability to create reusable layouts and partials. Jigsaw gives you access to all the templating features and control structures of Blade that are available in Laravel 5.4 (learn more about Blade layouts in the <a href="https://laravel.com/docs/5.4/blade">official Blade documentation</a>).</p>
+<p>One of the biggest benefits of a templating language is the ability to create reusable layouts and partials. Jigsaw gives you access to all the templating features and control structures of Blade that are available in Laravel 5.6 (learn more about Blade layouts in the <a href="https://laravel.com/docs/5.6/blade">official Blade documentation</a>).</p>
 <h3>Defining a Layout</h3>
 <p>Layouts themselves are just basic Blade templates that have one or more <code>@yield</code> calls where child templates can render their contents.</p>
 <p>A basic master layout could look like this:</p>

--- a/build_production/docs/collections/index.html
+++ b/build_production/docs/collections/index.html
@@ -140,7 +140,7 @@ This post is *profoundly* interesting.</code></pre>
 @yield('content')</code></pre>
 <h3>Accessing Collection Items</h3>
 <p>In any Blade template, you have access to each of your collections using a variable with the collection's name. This variable references an object that contains all the elements in your collection, and can be iterated over to
-access individual collection items. The collection variable also behaves as if it were an <a href="https://laravel.com/docs/5.4/collections">Illuminate Collection</a> in Laravel, meaning you have access to all of Laravel's standard collection methods like <code>count()</code>, <code>filter()</code>, and <code>where()</code>.</p>
+access individual collection items. The collection variable also behaves as if it were an <a href="https://laravel.com/docs/5.6/collections">Illuminate Collection</a> in Laravel, meaning you have access to all of Laravel's standard collection methods like <code>count()</code>, <code>filter()</code>, and <code>where()</code>.</p>
 <p>For example, to create a list of the titles for all your blog posts, you can iterate over the <code>$posts</code> object in a Blade <code>@foreach</code> loop, and display the <code>title</code> property that you defined in the YAML front matter of each post:</p>
 <blockquote>
 <p><em>posts.blade.php</em></p>

--- a/build_production/docs/compiling-assets/index.html
+++ b/build_production/docs/compiling-assets/index.html
@@ -81,7 +81,7 @@
         </div>
         <div class="col-md-9 documentation-page">
             <h2>Compiling Assets</h2>
-<p>Jigsaw sites are configured with support for <a href="http://laravel.com/docs/elixir">Laravel Elixir</a> out of the box. If you've ever used Elixir in a Laravel project, you already know how to use Elixir with Jigsaw.</p>
+<p>Jigsaw sites are configured with support for <a href="https://laravel.com/docs/5.2/elixir">Laravel Elixir</a> out of the box. If you've ever used Elixir in a Laravel project, you already know how to use Elixir with Jigsaw.</p>
 <h3>Setup</h3>
 <p>To get started, first make sure you have Node.js and NPM installed in your environment.</p>
 <p>Once you have Node.js and NPM installed, pull in the dependencies needed to compile your assets:</p>

--- a/source/docs/blade-templates-and-partials.md
+++ b/source/docs/blade-templates-and-partials.md
@@ -5,7 +5,7 @@ section: documentation_content
 
 ## Blade Templates & Partials
 
-One of the biggest benefits of a templating language is the ability to create reusable layouts and partials. Jigsaw gives you access to all the templating features and control structures of Blade that are available in Laravel 5.4 (learn more about Blade layouts in the [official Blade documentation](https://laravel.com/docs/5.4/blade)).
+One of the biggest benefits of a templating language is the ability to create reusable layouts and partials. Jigsaw gives you access to all the templating features and control structures of Blade that are available in Laravel 5.6 (learn more about Blade layouts in the [official Blade documentation](https://laravel.com/docs/5.6/blade)).
 
 ### Defining a Layout
 

--- a/source/docs/collections.md
+++ b/source/docs/collections.md
@@ -84,7 +84,7 @@ This post is *profoundly* interesting.
 ### Accessing Collection Items
 
 In any Blade template, you have access to each of your collections using a variable with the collection's name. This variable references an object that contains all the elements in your collection, and can be iterated over to
-access individual collection items. The collection variable also behaves as if it were an [Illuminate Collection](https://laravel.com/docs/5.4/collections) in Laravel, meaning you have access to all of Laravel's standard collection methods like `count()`, `filter()`, and `where()`.
+access individual collection items. The collection variable also behaves as if it were an [Illuminate Collection](https://laravel.com/docs/5.6/collections) in Laravel, meaning you have access to all of Laravel's standard collection methods like `count()`, `filter()`, and `where()`.
 
 For example, to create a list of the titles for all your blog posts, you can iterate over the `$posts` object in a Blade `@foreach` loop, and display the `title` property that you defined in the YAML front matter of each post:
 

--- a/source/docs/compiling-assets.md
+++ b/source/docs/compiling-assets.md
@@ -5,7 +5,7 @@ section: documentation_content
 
 ## Compiling Assets
 
-Jigsaw sites are configured with support for [Laravel Elixir](http://laravel.com/docs/elixir) out of the box. If you've ever used Elixir in a Laravel project, you already know how to use Elixir with Jigsaw.
+Jigsaw sites are configured with support for [Laravel Elixir](https://laravel.com/docs/5.2/elixir) out of the box. If you've ever used Elixir in a Laravel project, you already know how to use Elixir with Jigsaw.
 
 ### Setup
 


### PR DESCRIPTION
This PR updates the version references for Laravel in the text and links to 5.6. It also fixes a link to the Laravel Elixir docs.