### PR TITLE
Remove unintended day reference in custom path example

### DIFF
--- a/source/docs/collections-paths.md
+++ b/source/docs/collections-paths.md
@@ -38,7 +38,7 @@ If you included a date as a variable in your collection items (in YYYY-MM-DD for
 
 ```
 'path' => '{collection}/{published|Y-m-d}/{-title}'  // 'posts/2017-03-27/title-of-first-post'
-'path' => '{collection}/{published|Y/m}/{-title}'    // 'posts/2017/03/27/title-of-first-post'
+'path' => '{collection}/{published|Y/m}/{-title}'    // 'posts/2017/03/title-of-first-post'
 'path' => 'blog-{published|F-Y}/{-title}'            // 'blog-March-2017/title-of-first-post'
 ```
 


### PR DESCRIPTION
The current docs at https://jigsaw.tighten.co/docs/collections-paths/ currently say:

`'path' => '{collection}/{published|Y/m}/{-title}'    // 'posts/2017/03/27/title-of-first-post'`

when they should say:

`'path' => '{collection}/{published|Y/m}/{-title}'    // 'posts/2017/03/title-of-first-post'`