### PR TITLE
Fix typo in step 3 `Initialize your Project`

### DIFF
--- a/source/docs/installation.md
+++ b/source/docs/installation.md
@@ -35,7 +35,7 @@ $ composer require tightenco/jigsaw
 Finally, from your project directory, run Jigsaw's `init` command to scaffold the default directory structure:
 
 ```
-$ ./vendor/bin/jigsaw init
+$ vendor/bin/jigsaw init
 ```
 
 ---


### PR DESCRIPTION
When running `./vendor/bin/jigsaw init` from project directory you get an directory not found error, removed `./` from the command since we are in project directory and don't need to jump up a directory first. Simple enough.