### PR TITLE
Update blade examples with @section tag

### DIFF
--- a/source/docs/collections.md
+++ b/source/docs/collections.md
@@ -103,7 +103,7 @@ This post is *profoundly* interesting.
 ```
 @extends('_layouts.master')
 
-@section('content')
+@section('body')
     <h1>{{ $page->title }}</h1>
     <p>By {{ $page->author }} • {{ date('F j, Y', $page->date) }}</p>
 
@@ -145,7 +145,7 @@ In addition to the [metadata](/docs/page-metadata/) available for every page, su
 ```
 @extends('_layouts.master')
 
-@section('content')
+@section('body')
     <h1>{{ $page->title }}</h1>
 
     @yield('content')

--- a/source/docs/collections.md
+++ b/source/docs/collections.md
@@ -103,10 +103,12 @@ This post is *profoundly* interesting.
 ```
 @extends('_layouts.master')
 
-<h1>{{ $page->title }}</h1>
-<p>By {{ $page->author }} • {{ date('F j, Y', $page->date) }}</p>
+@section('content')
+    <h1>{{ $page->title }}</h1>
+    <p>By {{ $page->author }} • {{ date('F j, Y', $page->date) }}</p>
 
-@yield('content')
+    @yield('content')
+@endsection
 ```
 
 ### Accessing Collection Items
@@ -143,13 +145,15 @@ In addition to the [metadata](/docs/page-metadata/) available for every page, su
 ```
 @extends('_layouts.master')
 
-<h1>{{ $page->title }}</h1>
+@section('content')
+    <h1>{{ $page->title }}</h1>
 
-@yield('content')
+    @yield('content')
 
-@if ($page->getNext())
-    <p>Read my next post:
-        <a href="{{ $page->getNext()->getPath() }}">{{ $page->getNext()->title }}</a>
-    </p>
-@endif
+    @if ($page->getNext())
+        <p>Read my next post:
+            <a href="{{ $page->getNext()->getPath() }}">{{ $page->getNext()->title }}</a>
+        </p>
+    @endif
+@endsection
 ```


### PR DESCRIPTION
The current examples don't use the section tag which means their content will get prepended on top of the master layout. All other examples of the master layout use the section tag. This might confuse people on how blade works so it's best to stay consistent.