### PR TITLE
Fix a typo in starter-templates documentation text

### DIFF
--- a/source/docs/starter-templates.md
+++ b/source/docs/starter-templates.md
@@ -5,7 +5,7 @@ section: documentation_content
 
 ## Using a Starter Template
 
-To get you up and running with a fully-configured site quickly, Jigsaw includes two "starter templates"—one for a blog, one for open source documenation—that are ready for you to customize with your content. To use these templates as your starting point, simply add the name of the template to the `init` command:
+To get you up and running with a fully-configured site quickly, Jigsaw includes two "starter templates"—one for a blog, one for open source documentation—that are ready for you to customize with your content. To use these templates as your starting point, simply add the name of the template to the `init` command:
 
 ```bash
 ./vendor/bin/jigsaw init blog


### PR DESCRIPTION
Nice doc. Starting my first project with jigsaw and saw that typo so here you go.