### PR TITLE
Ensure the search input is always its full width

### DIFF
--- a/source/_layouts/documentation.blade.php
+++ b/source/_layouts/documentation.blade.php
@@ -14,7 +14,7 @@
         <div class="w-full flex items-center lg:max-w-md xl:max-w-lg border-2 border-indigo-lighter rounded bg-grey">
             <img src="/assets/img/icon-search.svg" class="absolute z-10 h-4 ml-2">
 
-            <input id="docsearch" type="text" class="pl-8 pr-2 py-2 bg-grey" placeholder='Search documentation (Press "/" to focus)' />
+            <input id="docsearch" type="text" class="w-full pl-8 pr-2 py-2 bg-grey" placeholder='Search documentation (Press "/" to focus)' />
         </div>
 
         <div class="hidden lg:flex lg:flex-1 items-center">


### PR DESCRIPTION
If for _some reason_ Algolia's scripts don't load correctly, the search input doesn't expand to its full width (at least on Firefox) because that setting is in the `.ds-input` class which is added dynamically.

This PR adds `.w-full` so the input looks nice no matter what.