### PR TITLE
fixes #59 Netlify requires PHP 7.4 to build

### DIFF
--- a/source/docs/deploying-your-site.md
+++ b/source/docs/deploying-your-site.md
@@ -42,7 +42,7 @@ To deploy a site to Netlify, first create a `netlify.toml` file with the followi
 
 command = "npm run production"
 publish = "build_production"
-environment = { PHP_VERSION = "7.2" }
+environment = { PHP_VERSION = "7.4" }
 ```
 
 Push this file to your repository.


### PR DESCRIPTION
Netlify's default build image is now PHP 7.4. There is an option (see image below) to set to PHP 7.2 image, but that won't satisfy current JigSaw dependencies.

Solution will require changing example config to use PHP 7.4 (7.3 won't work as not included in build image).

discussion re build image: https://github.com/netlify/build-image/pull/366


![screenshot_1591602066](https://user-images.githubusercontent.com/2066833/84004678-73509380-a95b-11ea-81b7-c447bce45a39.png)
