### PR TITLE
Update Netlify's PHP version

### DIFF
--- a/source/docs/deploying-your-site.md
+++ b/source/docs/deploying-your-site.md
@@ -42,7 +42,7 @@ To deploy a site to Netlify, first create a `netlify.toml` file with the followi
 
 command = "npm run production"
 publish = "build_production"
-environment = { PHP_VERSION = "7.2" }
+environment = { PHP_VERSION = "7.4" }
 ```
 
 Push this file to your repository.


### PR DESCRIPTION
Some Jigsaw dependencies require PHP version greater than 7.2, and this caused an error when deploying a fresh Jigsaw site to Netlify. Netlify now offers PHP version 7.4, and this change let me successfully deploy.